### PR TITLE
Add simple frontend tests

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import App from './index';
+
+describe('App component', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn((url, options) => {
+      if (url.startsWith('/api/watchlist')) {
+        return Promise.resolve({ json: () => Promise.resolve({ watchlist: [] }) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve({ price: 0 }) });
+    });
+  });
+
+  test('renders heading', () => {
+    const div = document.createElement('div');
+    const root = ReactDOM.createRoot(div);
+    TestUtils.act(() => {
+      root.render(<App />);
+    });
+    expect(div.querySelector('h1').textContent).toBe('Stock Watchlist');
+  });
+
+  test('adds a symbol', async () => {
+    const div = document.createElement('div');
+    const root = ReactDOM.createRoot(div);
+    await TestUtils.act(async () => {
+      root.render(<App />);
+    });
+    const input = div.querySelector('input[placeholder="Symbol"]');
+    const form = div.querySelector('form');
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.change(input, { target: { value: 'AAPL' } });
+    });
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.submit(form);
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/watchlist?symbol=AAPL', { method: 'POST' });
+  });
+});

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -75,5 +75,10 @@ function App() {
   );
 }
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}
+
+export default App;


### PR DESCRIPTION
## Summary
- export `App` from `index.js`
- only render the app if a root element is present
- add a basic Jest test suite for the frontend

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`